### PR TITLE
Support Pandas 2.0+

### DIFF
--- a/optimized-tco-calculator/hourly-agg-logs-generator/code/hourly-agg-log-generator.py
+++ b/optimized-tco-calculator/hourly-agg-logs-generator/code/hourly-agg-log-generator.py
@@ -229,10 +229,8 @@ if __name__ == '__main__':
                 
                 input_tco_cluster = temp_p_df2.groupby(['clusterType','clusterName','hour'],as_index=False).\
                                 agg({'memorySeconds':'mean','vcoreSeconds':'mean','elapsedTime':'mean'})
-       
 
-
-                final_input_tco_cluster = final_input_tco_cluster.append(input_tco_cluster)
+                final_input_tco_cluster = pd.concat([final_input_tco_cluster, input_tco_cluster])
 
         # T Type cluster aggreation from starhour - end hour
         t_emr_cluster = emr_cluster[emr_cluster['clusterType']=='T']
@@ -264,7 +262,8 @@ if __name__ == '__main__':
                     for h in np.roll(hours, -int(startHour)):
                         row = {'clusterType':'T', 'clusterName':name,'hour':h,'memorySeconds':mean_memory_usage,\
                                 'vcoreSeconds':mean_vcore_usage,"elapsedTime":mean_elapsed_time}
-                        final_input_tco_cluster = final_input_tco_cluster.append(row,ignore_index=True)
+                        df_row = pd.DataFrame(row, index = [0])
+                        final_input_tco_cluster = pd.concat([final_input_tco_cluster, df_row], ignore_index=True)
                       
                         if h == int(endHour) : break
 
@@ -279,7 +278,7 @@ if __name__ == '__main__':
                         s = pd.Series({'clusterType': temp.clusterType.iloc[0],'clusterName': c,\
                             'elapsedTime':0.1,'memorySeconds':0.1,'vcoreSeconds':0.1,'hour':h}, name=len(temp_df))
                         print("s.head:",s.head())
-                        final_input_tco_cluster = final_input_tco_cluster.append(s)
+                        final_input_tco_cluster = pd.concat([final_input_tco_cluster, s])
                         new_row_count = new_row_count + 1
 
         final_input_tco_cluster.sort_values(by=['clusterType','clusterName','hour'],ignore_index=True,inplace=True)

--- a/optimized-tco-calculator/hourly-agg-logs-generator/code/hourly-agg-log-generator.py
+++ b/optimized-tco-calculator/hourly-agg-logs-generator/code/hourly-agg-log-generator.py
@@ -178,7 +178,7 @@ if __name__ == '__main__':
     
     cluster_df = pd.read_excel(cluster_design,sheet_name='EMR Design Info')
     cluster_df.sort_values(by='clusterOrder',ignore_index=True,inplace=True)
-    cluster_df.fillna('ALL',inplace=True)
+    cluster_df[['queue', 'user', 'appType']] = cluster_df[['queue', 'user', 'appType']].fillna('ALL')
     cluster_df=cluster_df.apply(lambda x: x.str.upper() if x.dtype == "object" else x)
 
 # seperate yanlogs according to cluster design info 


### PR DESCRIPTION
*Issue #, if available:*

As DataFrame.append() is no longer supported since Pandas 2.0, it is necessary to use pandas.concat() instead.

*Description of changes:*
Any usages of DataFrame.append() are replaced by pandas.concat()

Reference:
- [Deprecated DataFrame.append and Series.append](https://pandas.pydata.org/pandas-docs/version/1.4/whatsnew/v1.4.0.html#deprecated-dataframe-append-and-series-append)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
